### PR TITLE
Use router interface instead of concrete router class

### DIFF
--- a/Instaphp/Instaphp.php
+++ b/Instaphp/Instaphp.php
@@ -33,7 +33,7 @@
 namespace Instaphp;
     
 use Symfony\Component\DependencyInjection\ContainerAware;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 use Oh\InstagramBundle\TokenHandler\TokenHandlerInterface;
 /**
  * A simple base class used to instantiate the various other API classes
@@ -86,7 +86,7 @@ class Instaphp extends ContainerAware
 
 	private static $instance = null;
 
-	public function __construct($tokenClass = null, $config = array(), Router $router = null)
+	public function __construct($tokenClass = null, $config = array(), RouterInterface $router = null)
 	{
 		if($tokenClass instanceof TokenHandlerInterface) {
 			$token = $tokenClass->getToken();


### PR DESCRIPTION
This allows other router classes to be used with the bundle (e.g. Symfony CMF's ChainRouter)
